### PR TITLE
6 update str pad@main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,12 +12,14 @@ Pre-review Checklist (if item does not apply, mark is as complete)
 - [ ] **All** GitHub Action workflows pass with a :white_check_mark:
 - [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
 - [ ] If a bug was fixed, a unit test was added.
+- [ ] If a standalone script was updated, a comment is added to the script header (changelog).
 - [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
 - [ ] Request a reviewer
 
 Reviewer Checklist (if item does not apply, mark is as complete)
 
 - [ ] If a bug was fixed, a unit test was added.
+- [ ] If a standalone script was updated, a comment is added to the script header (changelog).
 - [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
 - [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
 
@@ -26,3 +28,4 @@ When the branch is ready to be merged:
 - [ ] **All** GitHub Action workflows pass with a :white_check_mark:
 - [ ] Approve Pull Request
 - [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
+- [ ] Create an issue in any repositories using {standalone} to update the standalone scripts.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 **What changes are proposed in this pull request?**
-* Style this entry in a way that can be copied directly into `NEWS.md`. (#<issue number>, @<username>)
+(#<issue number>, @<username>)
 
 Provide more detail here as needed.
 
@@ -24,7 +24,6 @@ Reviewer Checklist (if item does not apply, mark is as complete)
 - [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
 
 When the branch is ready to be merged:
-- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
 - [ ] **All** GitHub Action workflows pass with a :white_check_mark:
 - [ ] Approve Pull Request
 - [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,0 @@
-# standalone 0.0.1
-
-* Initial release.

--- a/R/standalone-stringr.R
+++ b/R/standalone-stringr.R
@@ -11,6 +11,7 @@
 # of programming.
 #
 # ## Changelog
+# 2024-11-1 - `str_pad()` was updated to use `strrep()` instead of `sprintf()` (accommodates escape characters).
 #
 # nocov start
 # styler: off

--- a/R/standalone-stringr.R
+++ b/R/standalone-stringr.R
@@ -106,31 +106,25 @@ str_sub_all <- function(string, start = 1L, end = -1L) {
 str_pad <- function(string, width, side = c("left", "right", "both"), pad = " ", use_width = TRUE) {
   side <- match.arg(side)
 
-  # Calculate current lengths of strings
-  current_length <- nchar(string)
+  # allow vectorized input
+  padded_strings <- sapply(string, function(s) {
+    current_length <- nchar(s)
+    pad_length <- width - current_length
 
-  # Initialize the result vector
-  padded_string <- character(length(string))
-
-  for (i in seq_along(string)) {
-    if (current_length[i] >= width[i]) {
-      padded_string[i] <- string[i]
-    } else {
-      pad_length <- width[i] - current_length[i]
-
-      if (side == "both") {
-        pad_left <- pad_length %/% 2
-        pad_right <- pad_length - pad_left
-        padded_string[i] <- paste0(strrep(pad, pad_left), string[i], strrep(pad, pad_right))
-      } else if (side == "right") {
-        padded_string[i] <- paste0(string[i], strrep(pad, pad_length))
-      } else { # side == "left"
-        padded_string[i] <- paste0(strrep(pad, pad_length), string[i])
-      }
+    if (side == "both") {
+      pad_left <- pad_length %/% 2
+      pad_right <- pad_length - pad_left
+      padded_string <- paste0(strrep(pad, pad_left), s, strrep(pad, pad_right))
+    } else if (side == "right") {
+      padded_string <- paste0(s, strrep(pad, pad_length))
+    } else { # side == "left"
+      padded_string <- paste0(strrep(pad, pad_length), s)
     }
-  }
 
-  return(padded_string)
+    return(padded_string)
+  })
+
+  return(unname(padded_strings))
 }
 
 str_split <- function(string, pattern, n = Inf, fixed = FALSE, perl = !fixed) {

--- a/R/standalone-stringr.R
+++ b/R/standalone-stringr.R
@@ -103,19 +103,25 @@ str_sub_all <- function(string, start = 1L, end = -1L) {
   lapply(string, function(x) substr(x, start = start, stop = end))
 }
 
-str_pad <- function(string, width, side = c("left", "right", "both"), pad = " ", use_width = TRUE) {
-  side <- match.arg(side, c("left", "right", "both"))
+str_pad <- function(string, width, side = c("left", "right", "both"), pad = " ") {
+  side <- match.arg(side)
+
+  current_length <- nchar(string)
+
+  if (current_length >= width) {
+    return(string)
+  }
+
+  pad_length <- width - current_length
 
   if (side == "both") {
-    pad_left <- (width - nchar(string)) %/% 2
-    pad_right <- width - nchar(string) - pad_left
+    pad_left <- pad_length %/% 2
+    pad_right <- pad_length - pad_left
     padded_string <- paste0(strrep(pad, pad_left), string, strrep(pad, pad_right))
-  } else {
-    format_string <- ifelse(side == "right", paste0("%-", width, "s"),
-                            ifelse(side == "left", paste0("%", width, "s"),
-                                   paste0("%", width, "s")))
-
-    padded_string <- sprintf(format_string, string)
+  } else if (side == "right") {
+    padded_string <- paste0(string, strrep(pad, pad_length))
+  } else { # side == "left"
+    padded_string <- paste0(strrep(pad, pad_length), string)
   }
 
   return(padded_string)

--- a/R/standalone-stringr.R
+++ b/R/standalone-stringr.R
@@ -103,25 +103,31 @@ str_sub_all <- function(string, start = 1L, end = -1L) {
   lapply(string, function(x) substr(x, start = start, stop = end))
 }
 
-str_pad <- function(string, width, side = c("left", "right", "both"), pad = " ") {
+str_pad <- function(string, width, side = c("left", "right", "both"), pad = " ", use_width = TRUE) {
   side <- match.arg(side)
 
+  # Calculate current lengths of strings
   current_length <- nchar(string)
 
-  if (current_length >= width) {
-    return(string)
-  }
+  # Initialize the result vector
+  padded_string <- character(length(string))
 
-  pad_length <- width - current_length
+  for (i in seq_along(string)) {
+    if (current_length[i] >= width[i]) {
+      padded_string[i] <- string[i]
+    } else {
+      pad_length <- width[i] - current_length[i]
 
-  if (side == "both") {
-    pad_left <- pad_length %/% 2
-    pad_right <- pad_length - pad_left
-    padded_string <- paste0(strrep(pad, pad_left), string, strrep(pad, pad_right))
-  } else if (side == "right") {
-    padded_string <- paste0(string, strrep(pad, pad_length))
-  } else { # side == "left"
-    padded_string <- paste0(strrep(pad, pad_length), string)
+      if (side == "both") {
+        pad_left <- pad_length %/% 2
+        pad_right <- pad_length - pad_left
+        padded_string[i] <- paste0(strrep(pad, pad_left), string[i], strrep(pad, pad_right))
+      } else if (side == "right") {
+        padded_string[i] <- paste0(string[i], strrep(pad, pad_length))
+      } else { # side == "left"
+        padded_string[i] <- paste0(strrep(pad, pad_length), string[i])
+      }
+    }
   }
 
   return(padded_string)

--- a/tests/testthat/test-standalone-stringr.R
+++ b/tests/testthat/test-standalone-stringr.R
@@ -226,14 +226,23 @@ test_that("str_sub_all() works", {
 })
 
 test_that("str_pad() works", {
-  s <-  str_pad("hadley", 30, "left")
+  s <- str_pad("hadley", 30, "left")
   expect_identical(s, stringr::str_pad("hadley", 30, "left"))
 
   s <- str_pad("hadley", 30, "right")
-  expect_identical(s, stringr::str_pad("hadley", 30, "right"),)
+  expect_identical(s, stringr::str_pad("hadley", 30, "right"), )
 
   s <- str_pad("hadley", 30, "both")
   expect_identical(s, stringr::str_pad("hadley", 30, "both"))
+})
+
+test_that("str_pad() matches stringr::str_pad with escape characters", {
+  s <- "\"**Primary System Organ Class**  \\n    **Reported Term for the Adverse Event**\""
+
+  padded_string <- str_pad(s, 82, pad = " ", side = "right")
+  stringr_string <- stringr::str_pad(s, 82, pad = " ", side = "right")
+
+  expect_identical(padded_string, stringr_string)
 })
 
 test_that("word() works", {


### PR DESCRIPTION
closes #6 

Rework the `str_pad` function to remove use of `sprintf` for padding. now using `strrep()`

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
