### PR TITLE
Fix for fct_relevel for non-factor inputs

### DIFF
--- a/R/standalone-forcats.R
+++ b/R/standalone-forcats.R
@@ -1,7 +1,7 @@
 # ---
 # repo: insightsengineering/standalone
 # file: standalone-forcats.R
-# last-updated: 2025-02-24
+# last-updated: 2025-05-03
 # license: https://unlicense.org
 # imports:
 # ---
@@ -11,6 +11,8 @@
 # of programming.
 #
 # ## Changelog
+# 2025-05-03
+#   - `add fct_relevel()` fix for non-factor inputs
 # 2025-02-24
 #   - `add fct_relevel()` function.
 #
@@ -68,6 +70,7 @@ fct_na_value_to_level <- function(f, level = NA) {
 
 
 fct_relevel <- function(f, ..., after = 0L) {
+  if (!inherits(f, "factor")) f <- as.factor(f)
   old_levels <- levels(f)
   # Handle re-leveling function or specified levels
   first_levels <- if (rlang::dots_n(...) == 1L && (is.function(..1) || rlang::is_formula(..1))) {

--- a/tests/testthat/test-standalone-forcats.R
+++ b/tests/testthat/test-standalone-forcats.R
@@ -48,6 +48,7 @@ test_that("fct_relevel() works", {
   expect_equal(forcats::fct_relevel(f, "a", after = Inf), fct_relevel(f, "a", after = Inf))
   expect_equal(forcats::fct_relevel(f, rev), fct_relevel(f, rev))
   expect_equal(forcats::fct_relevel(f, ~rev(.x)), fct_relevel(f, ~rev(.x)))
+  expect_equal(forcats::fct_relevel(letters, "z"), fct_relevel(letters, "z"))
 
   # test for unobserved levels
   f_new <- fct_relevel(f, "b", "a", "d")  # "d" is unobserved


### PR DESCRIPTION
**What changes are proposed in this pull request?**
Fix in `fct_relevel()` for inputs that are not already a factor.

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] If a standalone script was updated, a comment is added to the script header (changelog) AND the `last-updated` field has been updated.
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] If a standalone script was updated, a comment is added to the script header (changelog) AND the `last-updated` field has been updated.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
- [ ] Create an issue in any repositories using {standalone} to update the standalone scripts.
