### PR TITLE
add fct reorder@main

### DIFF
--- a/R/standalone-forcats.R
+++ b/R/standalone-forcats.R
@@ -1,7 +1,7 @@
 # ---
 # repo: insightsengineering/standalone
 # file: standalone-forcats.R
-# last-updated: 2025-06-24
+# last-updated: 2025-07-25
 # license: https://unlicense.org
 # imports:
 # ---
@@ -11,6 +11,8 @@
 # of programming.
 #
 # ## Changelog
+# 2025-07-25
+#   - add `fct_reorder()` function.
 # 2025-06-24
 #   - add `fct_collapse()` function (and its internal helper functions).
 # 2025-05-03

--- a/R/standalone-forcats.R
+++ b/R/standalone-forcats.R
@@ -151,19 +151,21 @@ fct_collapse <- function(f, ..., other_level = NULL) {
   out
 }
 
-fct_reorder <- function(.f, .x, .fun = median, .na_rm = TRUE, .desc = FALSE, ...) {
+fct_reorder <- function(.f, .x, .fun = median, ..., .na_rm = NULL, .default = Inf, .desc = FALSE) {
   if (!inherits(.f, "factor")) .f <- factor(.f)
+  stopifnot(length(.f) == length(.x))
+  .fun <- as.function(.fun)
 
   lvls <- levels(.f)
 
   # Compute summary statistic per level
   summary_vals <- vapply(lvls, function(lvl) {
     vals <- .x[.f == lvl]
-    if (.na_rm) {
+    if (isTRUE(.na_rm)) {
       vals <- vals[!is.na(vals)]
     }
     if (length(vals) == 0) {
-      return(NA_real_)  # force NA for empty groups
+      return(.default)
     }
     .fun(vals, ...)
   }, numeric(1))

--- a/R/standalone-forcats.R
+++ b/R/standalone-forcats.R
@@ -151,5 +151,17 @@ fct_collapse <- function(f, ..., other_level = NULL) {
   out
 }
 
+fct_reorder <- function(.f, .x, .fun = median, .na_rm = NULL, .desc = FALSE, ...) {
+  if (!inherits(.f, "factor")) .f <- factor(.f)
+
+  # Compute summary values (if applicable)
+  summary_vals <- tapply(.x, .f, .fun, ..., simplify = TRUE)
+
+  # Order levels
+  new_levels <- names(sort(summary_vals, decreasing = .desc))
+
+  # Return reordered factor
+  factor(.f, levels = new_levels)
+}
 # nocov end
 # styler: on

--- a/tests/testthat/test-standalone-forcats.R
+++ b/tests/testthat/test-standalone-forcats.R
@@ -89,11 +89,11 @@ test_that("fct_* function behaviour when input is not a factor ", {
 test_that("fct_reorder() works", {
 
   f <- factor(c("WEEK 1", "WEEK 12", "WEEK 1", "WEEK 4", "WEEK 12", "WEEK 6"))
-  x <- c(1,12,1,4,12,6)
+  x <- c(1, 12, 1, 4, 12, 6)
 
   expect_equal(forcats::fct_reorder(f, x), fct_reorder(f, x))
   # levels before fct_reorder are alphabetical (week 12 before week 4)
-  expect_equal(levels(f),  c("WEEK 1",  "WEEK 12",  "WEEK 4",  "WEEK 6"))
+  expect_equal(levels(f), c("WEEK 1",  "WEEK 12",  "WEEK 4",  "WEEK 6"))
   #levels are ordered by x with fct_reorder
   expect_equal(levels(fct_reorder(f,x)), c("WEEK 1",  "WEEK 4",  "WEEK 6",  "WEEK 12"))
   expect_equal(levels(fct_reorder(f,x, .desc = TRUE)), c("WEEK 12",  "WEEK 6",  "WEEK 4",  "WEEK 1"))

--- a/tests/testthat/test-standalone-forcats.R
+++ b/tests/testthat/test-standalone-forcats.R
@@ -86,19 +86,6 @@ test_that("fct_* function behaviour when input is not a factor ", {
   expect_equal(forcats::fct_na_value_to_level(f, level = NA), fct_na_value_to_level(c, level = NA))
 })
 
-test_that("fct_collapse() works", {
-  f <- factor(c("b", "b", "a", "c", "c", "d"))
-  expect_equal(forcats::fct_collapse(f, ab = c("a", "b")), fct_collapse(f, ab = c("a", "b")))
-  expect_equal(
-    forcats::fct_collapse(f, ab = c("a", "b"), cd = c("c", "d")),
-    fct_collapse(f, ab = c("a", "b"), cd = c("c", "d"))
-  )
-  expect_equal(
-    forcats::fct_collapse(f, ab = c("a", "b"), other_level = "c"),
-    fct_collapse(f, ab = c("a", "b"), other_level = "c")
-  )
-})
-
 test_that("fct_reorder() works", {
 
   f <- factor(c("WEEK 1", "WEEK 12", "WEEK 1", "WEEK 4", "WEEK 12", "WEEK 6"))

--- a/tests/testthat/test-standalone-forcats.R
+++ b/tests/testthat/test-standalone-forcats.R
@@ -47,12 +47,12 @@ test_that("fct_relevel() works", {
   expect_equal(forcats::fct_relevel(fct_relevel(f, "b", "a")), fct_relevel(f, "b", "a"))
   expect_equal(forcats::fct_relevel(f, "a", after = Inf), fct_relevel(f, "a", after = Inf))
   expect_equal(forcats::fct_relevel(f, rev), fct_relevel(f, rev))
-  expect_equal(forcats::fct_relevel(f, ~rev(.x)), fct_relevel(f, ~rev(.x)))
+  expect_equal(forcats::fct_relevel(f, ~ rev(.x)), fct_relevel(f, ~ rev(.x)))
   expect_equal(forcats::fct_relevel(letters, "z"), fct_relevel(letters, "z"))
 
   # test for unobserved levels
-  f_new <- fct_relevel(f, "b", "a", "d")  # "d" is unobserved
-  expect_equal(levels(f_new), c("b", "a", "d", "c"))  # "d" should be added as a level, even though not observed
+  f_new <- fct_relevel(f, "b", "a", "d") # "d" is unobserved
+  expect_equal(levels(f_new), c("b", "a", "d", "c")) # "d" should be added as a level, even though not observed
 })
 
 test_that("fct_collapse() works", {
@@ -87,16 +87,15 @@ test_that("fct_* function behaviour when input is not a factor ", {
 })
 
 test_that("fct_reorder() works", {
-
   f <- factor(c("WEEK 1", "WEEK 12", "WEEK 1", "WEEK 4", "WEEK 12", "WEEK 6"))
   x <- c(1, 12, 1, 4, 12, 6)
 
   expect_equal(forcats::fct_reorder(f, x), fct_reorder(f, x))
   # levels before fct_reorder are alphabetical (week 12 before week 4)
-  expect_equal(levels(f), c("WEEK 1",  "WEEK 12",  "WEEK 4",  "WEEK 6"))
-  #levels are ordered by x with fct_reorder
-  expect_equal(levels(fct_reorder(f,x)), c("WEEK 1",  "WEEK 4",  "WEEK 6",  "WEEK 12"))
-  expect_equal(levels(fct_reorder(f,x, .desc = TRUE)), c("WEEK 12",  "WEEK 6",  "WEEK 4",  "WEEK 1"))
+  expect_equal(levels(f), c("WEEK 1", "WEEK 12", "WEEK 4", "WEEK 6"))
+  # levels are ordered by x with fct_reorder
+  expect_equal(levels(fct_reorder(f, x)), c("WEEK 1", "WEEK 4", "WEEK 6", "WEEK 12"))
+  expect_equal(levels(fct_reorder(f, x, .desc = TRUE)), c("WEEK 12", "WEEK 6", "WEEK 4", "WEEK 1"))
 
 
   # Test NA handling
@@ -105,4 +104,4 @@ test_that("fct_reorder() works", {
 
   # function handled NA as forcats does
   expect_equal(levels(forcats::fct_reorder(f1, x, .na_rm = FALSE)), levels(fct_reorder(f1, x, .na_rm = FALSE)))
-  })
+})

--- a/tests/testthat/test-standalone-forcats.R
+++ b/tests/testthat/test-standalone-forcats.R
@@ -85,3 +85,28 @@ test_that("fct_* function behaviour when input is not a factor ", {
   c <- as.character(f)
   expect_equal(forcats::fct_na_value_to_level(f, level = NA), fct_na_value_to_level(c, level = NA))
 })
+
+test_that("fct_collapse() works", {
+  f <- factor(c("b", "b", "a", "c", "c", "d"))
+  expect_equal(forcats::fct_collapse(f, ab = c("a", "b")), fct_collapse(f, ab = c("a", "b")))
+  expect_equal(
+    forcats::fct_collapse(f, ab = c("a", "b"), cd = c("c", "d")),
+    fct_collapse(f, ab = c("a", "b"), cd = c("c", "d"))
+  )
+  expect_equal(
+    forcats::fct_collapse(f, ab = c("a", "b"), other_level = "c"),
+    fct_collapse(f, ab = c("a", "b"), other_level = "c")
+  )
+})
+
+test_that("fct_reorder() works", {
+
+  f <- factor(c("WEEK 1", "WEEK 12", "WEEK 1", "WEEK 4", "WEEK 12", "WEEK 6"))
+  x <- c(1,12,1,4,12,6)
+
+  expect_equal(forcats::fct_reorder(f, x), fct_reorder(f, x))
+  # levels before fct_reorder are alphabetical (week 12 before week 4)
+  expect_equal(levels(f),  c("WEEK 1",  "WEEK 12",  "WEEK 4",  "WEEK 6"))
+  # levels are ordered by x with fct_reorder
+  expect_equal(levels(fct_reorder(f,x)), c("WEEK 1",  "WEEK 4",  "WEEK 6",  "WEEK 12"))
+})

--- a/tests/testthat/test-standalone-forcats.R
+++ b/tests/testthat/test-standalone-forcats.R
@@ -94,6 +94,15 @@ test_that("fct_reorder() works", {
   expect_equal(forcats::fct_reorder(f, x), fct_reorder(f, x))
   # levels before fct_reorder are alphabetical (week 12 before week 4)
   expect_equal(levels(f),  c("WEEK 1",  "WEEK 12",  "WEEK 4",  "WEEK 6"))
-  # levels are ordered by x with fct_reorder
+  #levels are ordered by x with fct_reorder
   expect_equal(levels(fct_reorder(f,x)), c("WEEK 1",  "WEEK 4",  "WEEK 6",  "WEEK 12"))
-})
+  expect_equal(levels(fct_reorder(f,x, .desc = TRUE)), c("WEEK 12",  "WEEK 6",  "WEEK 4",  "WEEK 1"))
+
+
+  # Test NA handling
+  f1 <- factor(c("a", "b", "c", "c"))
+  x <- c(3, 2, 1, NA)
+
+  # function handled NA as forcats does
+  expect_equal(levels(forcats::fct_reorder(f1, x, .na_rm = FALSE)), levels(fct_reorder(f1, x, .na_rm = FALSE)))
+  })


### PR DESCRIPTION
closes #22 

adding the fct_reorder function used in change_from_baseline tables (LBT01, VST01, etc).
Function orders the level of one factor based on another factor variable.

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] If a standalone script was updated, a comment is added to the script header (changelog) AND the `last-updated` field has been updated.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [x] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] If a bug was fixed, a unit test was added.
- [x] If a standalone script was updated, a comment is added to the script header (changelog) AND the `last-updated` field has been updated.
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
- [ ] Create an issue in any repositories using {standalone} to update the standalone scripts.
