### PR TITLE
Update package check functions, add `skip_if_not_pkg_installed()`

### DIFF
--- a/R/standalone-check_pkg_installed.R
+++ b/R/standalone-check_pkg_installed.R
@@ -33,6 +33,9 @@
 #'
 #' - `get_min_version_required()` will return, if any, the minimum version of `pkg` required by `ref`.
 #'
+#' - `skip_if_not_pkg_installed()` checks whether packages are installed and skips tests if any are
+#'   not installed.
+#'
 #' @param pkg (`character`)\cr
 #'   vector of package names to check.
 #' @param call (`environment`)\cr
@@ -171,6 +174,16 @@ get_min_version_required <- function(pkg, ref = utils::packageName(), lib.loc = 
     dplyr::filter(str_detect(.data$pkg, paste0(paste0(.env$pkg, "(\\s|$)"), collapse = "|")))
 
   res
+}
+
+skip_if_not_pkg_installed <- function(pkg,
+                                      ref = utils::packageName()) {
+  if (!is_pkg_installed(pkg, ref)) {
+    # skip if any required package is not installed
+    skip(message = "Not all required packages are installed")
+  } else {
+    invisible()
+  }
 }
 
 # nocov end

--- a/R/standalone-check_pkg_installed.R
+++ b/R/standalone-check_pkg_installed.R
@@ -170,14 +170,14 @@ get_min_version_required <- function(pkg, ref = utils::packageName(), lib.loc = 
     )
   }
 
-  # get the package_ref deps and subset on requested pkgs, also supplement df with pkgs
-  # that may not be proper deps of the reference package (these pkgs don't have min versions)
-  res <-
-    get_pkg_dependencies(ref, lib.loc = lib.loc) |>
-    dplyr::filter(str_detect(.data$pkg, paste0(paste0(.env$pkg, "(\\s|$)"), collapse = "|"))) |>
-    dplyr::full_join(dplyr::tibble(pkg = pkg), by = "pkg")
+  # get the package_ref deps and subset on requested pkgs
+  res <- get_pkg_dependencies(ref, lib.loc = lib.loc) |>
+    dplyr::filter(str_detect(.data$pkg, paste0(paste0(.env$pkg, "(\\s|$)"), collapse = "|")))
 
-  res
+  # supplement df with pkgs that may not be proper deps of the reference package (these pkgs don't have min versions)
+  pkg_add <- which(sapply(pkg, \(x) !grepl(x, paste0(res$pkg, collapse = "|")))) |> names()
+  res |>
+    dplyr::full_join(dplyr::tibble(pkg = pkg_add), by = "pkg")
 }
 
 skip_if_not_pkg_installed <- function(pkg,

--- a/R/standalone-check_pkg_installed.R
+++ b/R/standalone-check_pkg_installed.R
@@ -78,18 +78,13 @@ check_pkg_installed <- function(pkg,
   if (!is.character(ref) && !is.null(ref)) cli::cli_abort("{.arg ref} must be a string.")
 
   # get min version data -------------------------------------------------------
-  df_pkg_min_version <-
-    get_min_version_required(pkg = pkg, ref = ref)
+  df_pkg_min_version <- get_min_version_required(pkg = pkg, ref = ref)
 
   # prompt user to install package ---------------------------------------------
   rlang::check_installed(
     pkg = df_pkg_min_version$pkg,
-    version = df_pkg_min_version$version,
-    compare = df_pkg_min_version$compare,
     call = call
-  ) |>
-    # this can be removed after this issue is resolved https://github.com/r-lib/rlang/issues/1694
-    suppressWarnings()
+  )
 }
 
 #' @inheritParams check_pkg_installed
@@ -103,14 +98,15 @@ is_pkg_installed <- function(pkg,
   df_pkg_min_version <-
     get_min_version_required(pkg = pkg, ref = ref)
 
+
   # check installation TRUE/FALSE ----------------------------------------------
+  # any package is not installed
+  if (length(df_pkg_min_version$pkg) < length(pkg)) return(FALSE)
+
+  # all packages are installed - check for correct versions
   rlang::is_installed(
-    pkg = df_pkg_min_version$pkg,
-    version = df_pkg_min_version$version,
-    compare = df_pkg_min_version$compare
-  ) |>
-    # this can be removed after this issue is resolved https://github.com/r-lib/rlang/issues/1694
-    suppressWarnings()
+    pkg = df_pkg_min_version$pkg
+  )
 }
 
 #' @inheritParams check_pkg_installed
@@ -135,47 +131,20 @@ get_pkg_dependencies <- function(pkg = utils::packageName(), lib.loc = NULL) {
     unclass() |>
     dplyr::as_tibble() |>
     dplyr::select(
-      dplyr::any_of(c(
-        "Package", "Version", "Imports", "Depends",
-        "Suggests", "Enhances", "LinkingTo"
-      ))
+      dplyr::any_of(c("Imports", "Depends", "Suggests", "Enhances", "LinkingTo"))
     ) |>
-    dplyr::rename(
-      reference_pkg = "Package",
-      reference_pkg_version = "Version"
-    ) |>
-    tidyr::pivot_longer(
-      -dplyr::all_of(c("reference_pkg", "reference_pkg_version")),
-      values_to = "pkg",
-      names_to = "dependency_type",
-    ) |>
-    tidyr::separate_rows("pkg", sep = ",") |>
+    tidyr::pivot_longer(cols = everything(), names_to = NULL, values_to = "pkg") |>
+    tidyr::separate_longer_delim(everything(), delim = ",") |>
     dplyr::mutate(
       pkg = trimws(
         x = gsub(x = .data$pkg, pattern = "\\s+", replacement = " "),
         which = "both", whitespace = "[ \t\r\n]"
       )
-    ) |>
-    dplyr::filter(!is.na(.data$pkg)) |>
-    tidyr::separate(
-      .data$pkg,
-      into = c("pkg", "version"),
-      sep = " ", extra = "merge", fill = "right"
-    ) |>
-    dplyr::mutate(
-      compare = as.character(ifelse(regexpr("[>=<]+", .data$version) > 0,
-                       regmatches(.data$version, regexpr("[>=<]+", .data$version)),
-                       NA)),
-      version = gsub(pattern = "[\\(\\) >=<]", replacement = "", x = .data$version)
     )
 }
 
 .empty_pkg_deps_df <- function() {
-  dplyr::tibble(
-    reference_pkg = character(0L), reference_pkg_version = character(0L),
-    dependency_type = character(0L), pkg = character(0L),
-    version = character(0L), compare = character(0L)
-  )
+  dplyr::tibble(pkg = character(0L))
 }
 
 #' @inheritParams check_pkg_installed
@@ -199,11 +168,7 @@ get_min_version_required <- function(pkg, ref = utils::packageName(), lib.loc = 
   # that may not be proper deps of the reference package (these pkgs don't have min versions)
   res <-
     get_pkg_dependencies(ref, lib.loc = lib.loc) |>
-    dplyr::filter(.data$pkg %in% .env$pkg) |>
-    dplyr::full_join(
-      dplyr::tibble(pkg = pkg),
-      by = "pkg"
-    )
+    dplyr::filter(str_detect(.data$pkg, paste0(paste0(.env$pkg, "(\\s|$)"), collapse = "|")))
 
   res
 }

--- a/R/standalone-check_pkg_installed.R
+++ b/R/standalone-check_pkg_installed.R
@@ -36,8 +36,8 @@
 #'
 #' - `get_min_version_required()` will return, if any, the minimum version of `pkg` required by `ref`.
 #'
-#' - `skip_if_pkg_not_installed()` checks whether packages are installed and skips tests if any are
-#'   not installed.
+#' - `skip_if_pkg_not_installed()` checks whether packages are installed (with the minimum required version)
+#'    and skips tests if any are not installed.
 #'
 #' @param pkg (`character`)\cr
 #'   vector of package names to check.

--- a/R/standalone-check_pkg_installed.R
+++ b/R/standalone-check_pkg_installed.R
@@ -168,7 +168,7 @@ get_min_version_required <- function(pkg, ref = utils::packageName(), lib.loc = 
 
   # get the package_ref deps and subset on requested pkgs
   res <- get_pkg_dependencies(ref, lib.loc = lib.loc) |>
-    dplyr::filter(str_detect(.data$pkg, paste0(paste0(.env$pkg, "(\\s|$)"), collapse = "|")))
+    dplyr::filter(grepl(paste0(paste0(.env$pkg, "(\\s|$)"), collapse = "|"), .data$pkg))
 
   # supplement df with pkgs that may not be proper deps of the reference package (these pkgs don't have min versions)
   pkg_add <- which(sapply(pkg, \(x) !grepl(x, paste0(res$pkg, collapse = "|")))) |> names()

--- a/R/standalone-check_pkg_installed.R
+++ b/R/standalone-check_pkg_installed.R
@@ -185,9 +185,8 @@ skip_if_pkg_not_installed <- function(pkg,
     testthat::skip(message = paste(
       "Required package", shQuote(names(which(!pkg_installed))[1], type = "sh"), "is not installed"
     ))
-  } else {
-    invisible()
   }
+  invisible()
 }
 
 # nocov end

--- a/R/standalone-check_pkg_installed.R
+++ b/R/standalone-check_pkg_installed.R
@@ -182,7 +182,7 @@ skip_if_pkg_not_installed <- function(pkg,
   if (!all(pkg_installed)) {
     # skip if any required package is not installed
     testthat::skip(message = paste(
-      "Required package(s) not installed:", paste(shQuote(names(which(!pkg_installed)), type = "sh"), collapse = ", ")
+      "Required package", shQuote(names(which(!pkg_installed)), type = "sh"), "is not installed"
     ))
   } else {
     invisible()

--- a/R/standalone-check_pkg_installed.R
+++ b/R/standalone-check_pkg_installed.R
@@ -178,9 +178,12 @@ get_min_version_required <- function(pkg, ref = utils::packageName(), lib.loc = 
 
 skip_if_pkg_not_installed <- function(pkg,
                                       ref = utils::packageName()) {
-  if (!is_pkg_installed(pkg, ref)) {
+  pkg_installed <- sapply(pkg, is_pkg_installed, ref = ref)
+  if (!all(pkg_installed)) {
     # skip if any required package is not installed
-    testthat::skip(message = "Not all required packages are installed")
+    testthat::skip(message = paste(
+      "Required package(s) not installed:", paste(shQuote(names(which(!pkg_installed)), type = "sh"), collapse = ", ")
+    ))
   } else {
     invisible()
   }

--- a/R/standalone-check_pkg_installed.R
+++ b/R/standalone-check_pkg_installed.R
@@ -106,10 +106,6 @@ is_pkg_installed <- function(pkg,
 
 
   # check installation TRUE/FALSE ----------------------------------------------
-  # any package is not installed
-  if (length(df_pkg_min_version$pkg) < length(pkg)) return(FALSE)
-
-  # all packages are installed - check for correct versions
   rlang::is_installed(
     pkg = df_pkg_min_version$pkg
   )

--- a/R/standalone-check_pkg_installed.R
+++ b/R/standalone-check_pkg_installed.R
@@ -178,11 +178,12 @@ get_min_version_required <- function(pkg, ref = utils::packageName(), lib.loc = 
 
 skip_if_pkg_not_installed <- function(pkg,
                                       ref = utils::packageName()) {
-  pkg_installed <- sapply(pkg, is_pkg_installed, ref = ref)
+  pkg_deps <- get_min_version_required(pkg, ref = ref)
+  pkg_installed <- sapply(pkg_deps$pkg, rlang::is_installed)
   if (!all(pkg_installed)) {
     # skip if any required package is not installed
     testthat::skip(message = paste(
-      "Required package", shQuote(names(which(!pkg_installed)), type = "sh"), "is not installed"
+      "Required package", shQuote(names(which(!pkg_installed))[1], type = "sh"), "is not installed"
     ))
   } else {
     invisible()

--- a/R/standalone-check_pkg_installed.R
+++ b/R/standalone-check_pkg_installed.R
@@ -179,12 +179,14 @@ get_min_version_required <- function(pkg, ref = utils::packageName(), lib.loc = 
 skip_if_pkg_not_installed <- function(pkg,
                                       ref = utils::packageName()) {
   pkg_deps <- get_min_version_required(pkg, ref = ref)
-  pkg_installed <- sapply(pkg_deps$pkg, rlang::is_installed)
-  if (!all(pkg_installed)) {
-    # skip if any required package is not installed
-    testthat::skip(message = paste(
-      "Required package", shQuote(names(which(!pkg_installed))[1], type = "sh"), "is not installed"
-    ))
+  for (p in pkg_deps$pkg) {
+    pkg_installed <- rlang::is_installed(p)
+    if (!pkg_installed) {
+      # skip if any required package is not installed
+      testthat::skip(message = paste(
+        "Required package", shQuote(p, type = "sh"), "is not installed"
+      ))
+    }
   }
   invisible()
 }

--- a/R/standalone-check_pkg_installed.R
+++ b/R/standalone-check_pkg_installed.R
@@ -14,7 +14,7 @@
 #   - `get_pkg_dependencies()` was updated to use base r equivalents for `str_extract()` and `str_remove_all()`.
 #
 # 2025-10-03
-#   - `skip_if_not_pkg_installed()` was added.
+#   - `skip_if_pkg_not_installed()` was added.
 
 # nocov start
 # styler: off
@@ -36,7 +36,7 @@
 #'
 #' - `get_min_version_required()` will return, if any, the minimum version of `pkg` required by `ref`.
 #'
-#' - `skip_if_not_pkg_installed()` checks whether packages are installed and skips tests if any are
+#' - `skip_if_pkg_not_installed()` checks whether packages are installed and skips tests if any are
 #'   not installed.
 #'
 #' @param pkg (`character`)\cr
@@ -176,7 +176,7 @@ get_min_version_required <- function(pkg, ref = utils::packageName(), lib.loc = 
     dplyr::full_join(dplyr::tibble(pkg = pkg_add), by = "pkg")
 }
 
-skip_if_not_pkg_installed <- function(pkg,
+skip_if_pkg_not_installed <- function(pkg,
                                       ref = utils::packageName()) {
   if (!is_pkg_installed(pkg, ref)) {
     # skip if any required package is not installed

--- a/tests/testthat/test-standalone-check_pkg_installed.R
+++ b/tests/testthat/test-standalone-check_pkg_installed.R
@@ -69,3 +69,10 @@ test_that("check_pkg_installed() works", {
     0L
   )
 })
+
+test_that("skip_if_not_pkg_installed() works", {
+  skip_if_not_pkg_installed("dplyr")
+  expect_true(TRUE)
+
+  skip_if_not_pkg_installed("br000000m")
+})

--- a/tests/testthat/test-standalone-check_pkg_installed.R
+++ b/tests/testthat/test-standalone-check_pkg_installed.R
@@ -56,9 +56,6 @@ test_that("check_pkg_installed() works", {
   expect_error(
     check_pkg_installed("br000000m")
   )
-  expect_error(
-    check_pkg_installed("br000000m", fn = "test_fun()")
-  )
 
   expect_equal(
     get_pkg_dependencies(NULL) |> nrow(),

--- a/tests/testthat/test-standalone-check_pkg_installed.R
+++ b/tests/testthat/test-standalone-check_pkg_installed.R
@@ -12,30 +12,18 @@ test_that("check_pkg_installed() works", {
   expect_false(is_pkg_installed(c("dpl-eye-r", "tidyr")))
 
   expect_equal(
-    get_min_version_required("tidyselect", "dplyr") |>
-      dplyr::select(dependency_type, pkg, version, compare),
+    get_min_version_required("tidyselect", "dplyr"),
     dplyr::tibble(
-      dependency_type = "Imports",
-      pkg = "tidyselect",
-      version = "1.2.0",
-      compare = ">="
+      pkg = "tidyselect (>= 1.2.0)"
     )
   )
   expect_equal(
     get_min_version_required("brms", ref = NULL),
-    dplyr::tibble(
-      reference_pkg = NA_character_, reference_pkg_version = NA_character_,
-      dependency_type = NA_character_, pkg = "brms", version = NA_character_,
-      compare = NA_character_
-    )
+    dplyr::tibble(pkg = "brms")
   )
   expect_equal(
     get_min_version_required("dplyr", ref = NULL),
-    dplyr::tibble(
-      reference_pkg = NA_character_, reference_pkg_version = NA_character_,
-      dependency_type = NA_character_, pkg = "dplyr", version = NA_character_,
-      compare = NA_character_
-    )
+    dplyr::tibble(pkg = "dplyr")
   )
 
   expect_error(
@@ -49,7 +37,7 @@ test_that("check_pkg_installed() works", {
 
   expect_equal(
     names(df_deps),
-    c("reference_pkg", "reference_pkg_version", "dependency_type", "pkg", "version", "compare")
+    "pkg"
   )
 
   skip_if(interactive())

--- a/tests/testthat/test-standalone-check_pkg_installed.R
+++ b/tests/testthat/test-standalone-check_pkg_installed.R
@@ -71,5 +71,5 @@ test_that("skip_if_pkg_not_installed() works", {
   skip_if_pkg_not_installed("dplyr")
   expect_true(TRUE)
 
-  skip_if_pkg_not_installed("br000000m")
+  skip_if_pkg_not_installed(c("dplyr", "br000000m", "notapkg"))
 })

--- a/tests/testthat/test-standalone-check_pkg_installed.R
+++ b/tests/testthat/test-standalone-check_pkg_installed.R
@@ -67,9 +67,9 @@ test_that("check_pkg_installed() works", {
   )
 })
 
-test_that("skip_if_not_pkg_installed() works", {
-  skip_if_not_pkg_installed("dplyr")
+test_that("skip_if_pkg_not_installed() works", {
+  skip_if_pkg_not_installed("dplyr")
   expect_true(TRUE)
 
-  skip_if_not_pkg_installed("br000000m")
+  skip_if_pkg_not_installed("br000000m")
 })


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Simplified code in functions used for package checks.
* Added function `skip_if_not_pkg_installed()` to skip tests if required packages are not installed.

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] If a standalone script was updated, a comment is added to the script header (changelog) AND the `last-updated` field has been updated.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [x] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] If a bug was fixed, a unit test was added.
- [x] If a standalone script was updated, a comment is added to the script header (changelog) AND the `last-updated` field has been updated.
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] Approve Pull Request
- [x] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
- [x] Create an issue in any repositories using {standalone} to update the standalone scripts.
